### PR TITLE
FIX: Player page can't be opened on macOS

### DIFF
--- a/src/constants/DownloadPage/index.tsx
+++ b/src/constants/DownloadPage/index.tsx
@@ -42,6 +42,17 @@ export const DEVICE_INFO: TDeviceTypes[] = [
     badge: <img src={MicrosoftBadge} />,
   },
   {
+    name: EDeviceTypes.Mac,
+    os: EOSTypes.macOS,
+    store: EOSStore.AppStore,
+    screenType: EScreenTypes.Desktop,
+    link: {
+      onDevice: 'itms-apps://apps.apple.com/us/app/spotify-music-and-podcasts/id324684580',
+      onOtherDevices: 'https://apps.apple.com/us/app/spotify-music-and-podcasts/id324684580',
+    },
+    badge: <AppStoreBadge />,
+  },
+  {
     name: EDeviceTypes.iPad,
     os: EOSTypes.ipadOS,
     store: EOSStore.AppStore,

--- a/src/types/WebSite/DownloadPage/index.tsx
+++ b/src/types/WebSite/DownloadPage/index.tsx
@@ -6,6 +6,7 @@ export enum EDeviceTypes {
   Android = 'Android',
   iPhone = 'iPhone',
   iPad = 'iPad',
+  Mac = 'Macintosh',
 }
 
 export enum EOSTypes {

--- a/src/views/Layout/WebPlayer/index.tsx
+++ b/src/views/Layout/WebPlayer/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, lazy, Suspense } from 'react';
 import { useUser } from 'contexts/UserContext';
 import { useUserOs } from 'hooks/useUserOs';
-import { EOSTypes } from 'types/WebSite/DownloadPage';
+import { EOSTypes, EScreenTypes } from 'types/WebSite/DownloadPage';
 import useGetActiveSubComponent from './Header/hooks/useGetActiveSubComponent';
 import SpotifySpinner from 'assets/spinners/spotify-spinner';
 import './style.scss';
@@ -37,7 +37,7 @@ const WebPlayerLayout = () => {
     return <div className="flex justify-center mt-10 uppercase font-semibold">Mobile version is under development</div>;
   };
 
-  return userDeviceType?.os === EOSTypes.Windows ? getDesktopVersion() : getMobileVersion();
+  return userDeviceType?.screenType === EScreenTypes.Desktop ? getDesktopVersion() : getMobileVersion();
 };
 
 export default WebPlayerLayout;


### PR DESCRIPTION
FIX: Player page can't be opened on macOS due to lack of specified OS types